### PR TITLE
PEN-1911: Update to 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/handlebars-v4",
-  "version": "4.0.14",
+  "version": "4.2.1",
   "description": "A simple wrapper for handlebars.js v4",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/bigcommerce/handlebars-v4",
   "dependencies": {
-    "handlebars": "4.0.14"
+    "handlebars": "4.2.1"
   }
 }


### PR DESCRIPTION
Updating to 4.2.1. Will also loop back and update to latest later, but want to have this version available because of a potential breaking change introduced in 4.3.0.
